### PR TITLE
Fix gatsby-plugin-offline defaults in Readme

### DIFF
--- a/packages/gatsby-plugin-offline/README.md
+++ b/packages/gatsby-plugin-offline/README.md
@@ -33,12 +33,11 @@ const options = {
   globDirectory: rootDir,
   globPatterns,
   modifyUrlPrefix: {
-    rootDir: ``,
     // If `pathPrefix` is configured by user, we should replace
     // the default prefix with `pathPrefix`.
-    "": args.pathPrefix || ``,
+    "/": `${pathPrefix}/`,
   },
-  navigateFallback: `/offline-plugin-app-shell-fallback/index.html`,
+  navigateFallback: `${pathPrefix}/offline-plugin-app-shell-fallback/index.html`,
   // Only match URLs without extensions or the query `no-cache=1`.
   // So example.com/about/ will pass but
   // example.com/about/?no-cache=1 and
@@ -47,16 +46,21 @@ const options = {
   // URLs and not any files hosted on the site.
   //
   // Regex based on http://stackoverflow.com/a/18017805
-  navigateFallbackWhitelist: [/^[^?]*([^.?]{5}|\.html)(\?.*)?$/],
+  navigateFallbackWhitelist: [/^([^.?]*|[^?]*\.([^.?]{5,}|html))(\?.*)?$/],
   navigateFallbackBlacklist: [/\?(.+&)?no-cache=1$/],
   cacheId: `gatsby-plugin-offline`,
-  // Don't cache-bust JS files and anything in the static directory
-  dontCacheBustUrlsMatching: /(.*js$|\/static\/)/,
+  // Don't cache-bust JS or CSS files, and anything in the static directory
+  dontCacheBustUrlsMatching: /(.*\.js$|.*\.css$|\/static\/)/,
   runtimeCaching: [
     {
       // Add runtime caching of various page resources.
       urlPattern: /\.(?:png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
       handler: `staleWhileRevalidate`,
+    },
+    {
+      // Use the Network First handler for external resources
+      urlPattern: /^https?:/,
+      handler: `networkFirst`,
     },
   ],
   skipWaiting: true,


### PR DESCRIPTION
I've noticed the Readme of gatsby-plugin-offline is out of sync with the actual defaults from its gatsby-node.js.

This commit fixes this by copying the options object from gatsby/packages/gatsby-plugin-offline/src/gatsby-node.js into this Readme.

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
